### PR TITLE
Merge latest changes from personal into main

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Git pre-push hook: enforce canonical links only when pushing local main
+# Canonical target: watzon/cursor-linux-installer@main
+
+# Read remote name/url provided by git
+remote_name=${1:-}
+remote_url=${2:-}
+
+should_check=false
+main_local_sha=""
+main_remote_sha=""
+while read -r local_ref local_sha remote_ref remote_sha; do
+  if [ "$local_ref" = "refs/heads/main" ] || [ "$remote_ref" = "refs/heads/main" ]; then
+    should_check=true
+    main_local_sha="$local_sha"
+    main_remote_sha="$remote_sha"
+    break
+  fi
+done
+
+if [ "$should_check" = true ]; then
+  echo "pre-push: enforcing canonical links for main (remote=$remote_name url=$remote_url local_sha=$main_local_sha remote_sha=$main_remote_sha)..."
+  hook_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+  bash "$hook_dir/../scripts/check-links.sh"
+fi
+
+exit 0
+
+

--- a/.github/workflows/enforce-canonical.yml
+++ b/.github/workflows/enforce-canonical.yml
@@ -1,0 +1,22 @@
+name: Enforce Canonical Links
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Make scripts executable
+        run: |
+          chmod +x scripts/check-links.sh || true
+
+      - name: Verify canonical links and defaults
+        run: |
+          bash scripts/check-links.sh

--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ The installation script will:
 2. Make the script executable
 3. Download and install the latest version of Cursor
 
+**Note:** If you're installing via the piped bash method and don't have FUSE2 installed, the script will warn you but continue. You'll need to either:
+
+- Install FUSE2 manually: `sudo apt-get install libfuse2` (Debian/Ubuntu), `sudo dnf install fuse` (Fedora), or `sudo pacman -S fuse2` (Arch)
+- Use extracted mode: `curl -fsSL https://raw.githubusercontent.com/ZanzyTHEbar/cursor-linux-installer/personal/install.sh | bash -s -- stable --extract`
+
 ## Uninstalling
 
 To uninstall the Cursor Linux Installer, you can run the uninstall script:

--- a/README.md
+++ b/README.md
@@ -15,21 +15,27 @@ You can install the Cursor Linux Installer using either curl or wget. Choose the
 ### Using curl
 
 ```bash
-# Install stable version (default)
+# Install stable version (default, AppImage mode)
 curl -fsSL https://raw.githubusercontent.com/ZanzyTHEbar/cursor-linux-installer/personal/install.sh | bash
 
 # Install latest version
 curl -fsSL https://raw.githubusercontent.com/ZanzyTHEbar/cursor-linux-installer/personal/install.sh | bash -s -- latest
+
+# Install in extracted mode (no FUSE required)
+curl -fsSL https://raw.githubusercontent.com/ZanzyTHEbar/cursor-linux-installer/personal/install.sh | bash -s -- stable --extract
 ```
 
 ### Using wget
 
 ```bash
-# Install stable version (default)
+# Install stable version (default, AppImage mode)
 wget -qO- https://raw.githubusercontent.com/ZanzyTHEbar/cursor-linux-installer/personal/install.sh | bash
 
 # Install latest version
 wget -qO- https://raw.githubusercontent.com/ZanzyTHEbar/cursor-linux-installer/personal/install.sh | bash -s -- latest
+
+# Install in extracted mode (no FUSE required)
+wget -qO- https://raw.githubusercontent.com/ZanzyTHEbar/cursor-linux-installer/personal/install.sh | bash -s -- stable --extract
 ```
 
 The installation script will:
@@ -71,6 +77,60 @@ After installation, you can use the `cursor` command to launch Cursor or update 
 - To check Cursor version: `cursor --version` or `cursor -v`
   - Shows the installed version of Cursor if available
   - Returns an error if Cursor is not installed or version cannot be determined
+
+## Installation Modes
+
+The installer supports two installation modes:
+
+### AppImage Mode (Default)
+
+The default mode installs Cursor as an AppImage. This requires FUSE2 to be installed on your system.
+
+**Requirements:**
+
+- FUSE2 (automatically installed by the script on Debian/Ubuntu, Fedora, and Arch)
+
+**Advantages:**
+
+- Smaller disk footprint
+- Standard AppImage format
+
+**Usage:**
+
+```bash
+cursor --update stable
+```
+
+### Extracted Mode (FUSE-Free)
+
+This mode fully extracts the AppImage and installs Cursor as a native application, **eliminating the need for FUSE**. This is ideal for:
+
+- Systems without FUSE support
+- Restricted environments (containers, some cloud instances)
+- Users who prefer traditional installations
+
+**Advantages:**
+
+- No FUSE dependency
+- Works in restricted environments
+- Native application structure
+- Potentially better compatibility
+
+**Usage:**
+
+```bash
+# Install in extracted mode
+cursor --extract
+
+# Update in extracted mode
+cursor --extract --update stable
+
+# Set as default via environment variable
+export CURSOR_INSTALL_MODE=extracted
+cursor --update stable
+```
+
+**Note:** The extracted installation is stored in `~/.local/share/cursor/` and takes up more disk space (~500MB) compared to the AppImage.
 
 ## Note
 

--- a/README.md
+++ b/README.md
@@ -16,20 +16,20 @@ You can install the Cursor Linux Installer using either curl or wget. Choose the
 
 ```bash
 # Install stable version (default)
-curl -fsSL https://raw.githubusercontent.com/watzon/cursor-linux-installer/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/ZanzyTHEbar/cursor-linux-installer/main/install.sh | bash
 
 # Install latest version
-curl -fsSL https://raw.githubusercontent.com/watzon/cursor-linux-installer/main/install.sh | bash -s -- latest
+curl -fsSL https://raw.githubusercontent.com/ZanzyTHEbar/cursor-linux-installer/main/install.sh | bash -s -- latest
 ```
 
 ### Using wget
 
 ```bash
 # Install stable version (default)
-wget -qO- https://raw.githubusercontent.com/watzon/cursor-linux-installer/main/install.sh | bash
+wget -qO- https://raw.githubusercontent.com/ZanzyTHEbar/cursor-linux-installer/main/install.sh | bash
 
 # Install latest version
-wget -qO- https://raw.githubusercontent.com/watzon/cursor-linux-installer/main/install.sh | bash -s -- latest
+wget -qO- https://raw.githubusercontent.com/ZanzyTHEbar/cursor-linux-installer/main/install.sh | bash -s -- latest
 ```
 
 The installation script will:
@@ -43,13 +43,13 @@ The installation script will:
 To uninstall the Cursor Linux Installer, you can run the uninstall script:
 
 ```bash
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/watzon/cursor-linux-installer/main/uninstall.sh)"
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/ZanzyTHEbar/cursor-linux-installer/main/uninstall.sh)"
 ```
 
 or
 
 ```bash
-bash -c "$(wget -qO- https://raw.githubusercontent.com/watzon/cursor-linux-installer/main/uninstall.sh)"
+bash -c "$(wget -qO- https://raw.githubusercontent.com/ZanzyTHEbar/cursor-linux-installer/main/uninstall.sh)"
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -108,13 +108,13 @@ Maintainer workflow:
 To uninstall the Cursor Linux Installer, you can run the uninstall script:
 
 ```bash
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/ZanzyTHEbar/cursor-linux-installer/personal/uninstall.sh)"
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/watzon/cursor-linux-installer/main/uninstall.sh)"
 ```
 
 or
 
 ```bash
-bash -c "$(wget -qO- https://raw.githubusercontent.com/ZanzyTHEbar/cursor-linux-installer/personal/uninstall.sh)"
+bash -c "$(wget -qO- https://raw.githubusercontent.com/watzon/cursor-linux-installer/main/uninstall.sh)"
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,35 +10,35 @@ This repository aims to solve that problem by providing a set of shell scripts t
 
 ## Installation
 
-You can install the Cursor Linux Installer using either curl or wget. Choose the method you prefer:
+There are two ways to install, depending on whether you want to run from the GitHub one-liner or from a locally cloned repository.
 
-### Using curl
-
-```bash
-# Install stable version (default, AppImage mode)
-curl -fsSL https://raw.githubusercontent.com/ZanzyTHEbar/cursor-linux-installer/personal/install.sh | bash
-
-# Install latest version
-curl -fsSL https://raw.githubusercontent.com/ZanzyTHEbar/cursor-linux-installer/personal/install.sh | bash -s -- latest
-
-# Install in extracted mode (no FUSE required)
-curl -fsSL https://raw.githubusercontent.com/ZanzyTHEbar/cursor-linux-installer/personal/install.sh | bash -s -- stable --extract
-```
-
-### Using wget
+### Method 1: One‑liner (curl)
 
 ```bash
 # Install stable version (default, AppImage mode)
-wget -qO- https://raw.githubusercontent.com/ZanzyTHEbar/cursor-linux-installer/personal/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/watzon/cursor-linux-installer/main/install.sh | bash
 
 # Install latest version
-wget -qO- https://raw.githubusercontent.com/ZanzyTHEbar/cursor-linux-installer/personal/install.sh | bash -s -- latest
+curl -fsSL https://raw.githubusercontent.com/watzon/cursor-linux-installer/main/install.sh | bash -s -- latest
 
 # Install in extracted mode (no FUSE required)
-wget -qO- https://raw.githubusercontent.com/ZanzyTHEbar/cursor-linux-installer/personal/install.sh | bash -s -- stable --extract
+curl -fsSL https://raw.githubusercontent.com/watzon/cursor-linux-installer/main/install.sh | bash -s -- stable --extract
 ```
 
-The installation script will:
+### Method 1: One‑liner (wget)
+
+```bash
+# Install stable version (default, AppImage mode)
+wget -qO- https://raw.githubusercontent.com/watzon/cursor-linux-installer/main/install.sh | bash
+
+# Install latest version
+wget -qO- https://raw.githubusercontent.com/watzon/cursor-linux-installer/main/install.sh | bash -s -- latest
+
+# Install in extracted mode (no FUSE required)
+wget -qO- https://raw.githubusercontent.com/watzon/cursor-linux-installer/main/install.sh | bash -s -- stable --extract
+```
+
+The one‑liner script will:
 
 1. Download the `cursor.sh` script and save it as `cursor` in `~/.local/bin/`
 2. Make the script executable
@@ -47,7 +47,61 @@ The installation script will:
 **Note:** If you're installing via the piped bash method and don't have FUSE2 installed, the script will warn you but continue. You'll need to either:
 
 - Install FUSE2 manually: `sudo apt-get install libfuse2` (Debian/Ubuntu), `sudo dnf install fuse` (Fedora), or `sudo pacman -S fuse2` (Arch)
-- Use extracted mode: `curl -fsSL https://raw.githubusercontent.com/ZanzyTHEbar/cursor-linux-installer/personal/install.sh | bash -s -- stable --extract`
+- Use extracted mode: `curl -fsSL https://raw.githubusercontent.com/watzon/cursor-linux-installer/main/install.sh | bash -s -- stable --extract`
+
+### Method 2: Local clone
+
+```bash
+git clone https://github.com/watzon/cursor-linux-installer.git
+cd cursor-linux-installer
+
+# AppImage mode (default)
+./install.sh stable
+
+# Latest release
+./install.sh latest
+
+# Extracted, no-FUSE mode
+./install.sh latest --extract
+```
+
+When you run `./install.sh` from the repo, it uses the local `cursor.sh` instead of downloading from GitHub.
+
+### Maintainers: Switching between personal and canonical repos
+
+This fork uses a personal branch for development and the upstream repo for canonical links. The installer supports environment overrides so you can test personal builds without modifying repo defaults:
+
+```bash
+# (Optional) Personal testing without editing repo defaults
+export REPO_OWNER="ZanzyTHEbar"
+export REPO_BRANCH="personal"
+./install.sh latest
+```
+
+CI or release scripts can set these env vars to ensure links point to the canonical repo in artifacts and docs.
+
+#### Branch protection and automation
+
+This repository enforces that `main` always points to the canonical upstream (`watzon/cursor-linux-installer`).
+
+- A GitHub Action (`.github/workflows/enforce-canonical.yml`) runs on pushes and PRs to `main` and fails if:
+  - Any personal links like `ZanzyTHEbar/cursor-linux-installer/personal` are present in tracked files.
+  - `install.sh` defaults are not `REPO_OWNER=watzon` and `REPO_BRANCH=main`.
+
+Maintainer workflow:
+
+1. Develop on personal branch.
+2. Merge to `main` in your fork.
+3. Canonical defaults are used automatically (`watzon/main`). For personal testing, use the env overrides shown above.
+
+4. Enable local git hook to prevent pushing non-canonical links to main:
+
+   ```bash
+   git config core.hooksPath .githooks
+   chmod +x .githooks/pre-push
+   ```
+
+5. Open PR to upstream. CI will verify canonical links.
 
 ## Uninstalling
 
@@ -135,7 +189,7 @@ export CURSOR_INSTALL_MODE=extracted
 cursor --update stable
 ```
 
-**Note:** The extracted installation is stored in `~/.local/share/cursor/` and takes up more disk space (~500MB) compared to the AppImage.
+**Note:** The extracted installation is stored in `~/.local/share/cursor/`.
 
 ## Note
 

--- a/README.md
+++ b/README.md
@@ -16,20 +16,20 @@ You can install the Cursor Linux Installer using either curl or wget. Choose the
 
 ```bash
 # Install stable version (default)
-curl -fsSL https://raw.githubusercontent.com/ZanzyTHEbar/cursor-linux-installer/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/ZanzyTHEbar/cursor-linux-installer/personal/install.sh | bash
 
 # Install latest version
-curl -fsSL https://raw.githubusercontent.com/ZanzyTHEbar/cursor-linux-installer/main/install.sh | bash -s -- latest
+curl -fsSL https://raw.githubusercontent.com/ZanzyTHEbar/cursor-linux-installer/personal/install.sh | bash -s -- latest
 ```
 
 ### Using wget
 
 ```bash
 # Install stable version (default)
-wget -qO- https://raw.githubusercontent.com/ZanzyTHEbar/cursor-linux-installer/main/install.sh | bash
+wget -qO- https://raw.githubusercontent.com/ZanzyTHEbar/cursor-linux-installer/personal/install.sh | bash
 
 # Install latest version
-wget -qO- https://raw.githubusercontent.com/ZanzyTHEbar/cursor-linux-installer/main/install.sh | bash -s -- latest
+wget -qO- https://raw.githubusercontent.com/ZanzyTHEbar/cursor-linux-installer/personal/install.sh | bash -s -- latest
 ```
 
 The installation script will:
@@ -43,13 +43,13 @@ The installation script will:
 To uninstall the Cursor Linux Installer, you can run the uninstall script:
 
 ```bash
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/ZanzyTHEbar/cursor-linux-installer/main/uninstall.sh)"
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/ZanzyTHEbar/cursor-linux-installer/personal/uninstall.sh)"
 ```
 
 or
 
 ```bash
-bash -c "$(wget -qO- https://raw.githubusercontent.com/ZanzyTHEbar/cursor-linux-installer/main/uninstall.sh)"
+bash -c "$(wget -qO- https://raw.githubusercontent.com/ZanzyTHEbar/cursor-linux-installer/personal/uninstall.sh)"
 
 ```
 

--- a/cursor.sh
+++ b/cursor.sh
@@ -172,8 +172,8 @@ function get_fallback_download_info() {
     fi
     local fallback_hash="8ea935e79a50a02da912a034bbeda84a6d3d355d"  # FIXED: Recent from 0.50.4 (May 2025)
     local fallback_version="0.50.4"  # FIXED: Updated version
-    echo "FALLBACK_URL=https://downloads.cursor.com/production/$fallback_hash/linux/$path_arch/Cursor-$fallback_version-$file_arch.AppImage"
-    echo "FALLBACK_VERSION=$fallback_version"
+    echo "URL=https://downloads.cursor.com/production/$fallback_hash/linux/$path_arch/Cursor-$fallback_version-$file_arch.AppImage"
+    echo "VERSION=$fallback_version"
     return 1  # Still error, but usable URL
 }
 

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 set -e
 
 # URL of the cursor.sh script in the GitHub repository
-CURSOR_SCRIPT_URL="https://raw.githubusercontent.com/ZanzyTHEbar/cursor-linux-installer/main/cursor.sh"
+CURSOR_SCRIPT_URL="https://raw.githubusercontent.com/ZanzyTHEbar/cursor-linux-installer/personal/cursor.sh"
 
 # Local bin directory
 LOCAL_BIN="$HOME/.local/bin"

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,19 @@
 
 set -e
 
+# Color and logging helpers
+if [ -t 1 ]; then
+    BOLD="\033[1m"; RESET="\033[0m"; RED="\033[31m"; GREEN="\033[32m"; YELLOW="\033[33m"; BLUE="\033[34m"
+else
+    BOLD=""; RESET=""; RED=""; GREEN=""; YELLOW=""; BLUE=""
+fi
+
+log_info()  { echo -e "${BLUE}[*]${RESET} $*"; }
+log_ok()    { echo -e "${GREEN}[✓]${RESET} $*"; }
+log_warn()  { echo -e "${YELLOW}[!]${RESET} $*"; }
+log_error() { echo -e "${RED}[x]${RESET} $*"; }
+log_step()  { echo -e "${BOLD}$*${RESET}"; }
+
 # Parse arguments
 RELEASE_TRACK="stable"
 INSTALL_MODE="appimage"
@@ -12,20 +25,33 @@ while [[ $# -gt 0 ]]; do
             INSTALL_MODE="extracted"
             shift
             ;;
+        --stable|--latest)
+            RELEASE_TRACK="${1#--}"
+            shift
+            ;;
         stable|latest)
             RELEASE_TRACK="$1"
             shift
             ;;
         *)
-            echo "Unknown option: $1"
-            echo "Usage: bash install.sh [stable|latest] [--extract|--no-fuse]"
+    echo "Unknown option: $1"
+    echo "Usage: bash install.sh [stable|latest] [--extract|--no-fuse]"
+    echo "Environment overrides: REPO_OWNER, REPO_NAME, REPO_BRANCH"
             exit 1
             ;;
     esac
 done
 
-# URL of the cursor.sh script in the GitHub repository
-CURSOR_SCRIPT_URL="https://raw.githubusercontent.com/ZanzyTHEbar/cursor-linux-installer/personal/cursor.sh"
+# Determine whether to use local cursor.sh or download from GitHub
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+LOCAL_CURSOR_SH="$SCRIPT_DIR/cursor.sh"
+
+# Repo URL parameters (override via env for release workflows)
+REPO_OWNER=${REPO_OWNER:-watzon}
+REPO_BRANCH=${REPO_BRANCH:-main}
+REPO_NAME=${REPO_NAME:-cursor-linux-installer}
+BASE_RAW_URL="https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/${REPO_BRANCH}"
+CURSOR_SCRIPT_URL="$BASE_RAW_URL/cursor.sh"
 
 # Local bin directory
 LOCAL_BIN="$HOME/.local/bin"
@@ -33,29 +59,38 @@ LOCAL_BIN="$HOME/.local/bin"
 # Create ~/.local/bin if it doesn't exist
 mkdir -p "$LOCAL_BIN"
 
-# Download cursor.sh and save it as 'cursor' in ~/.local/bin
-echo "Downloading Cursor installer script..."
-curl -fsSL "$CURSOR_SCRIPT_URL" -o "$LOCAL_BIN/cursor"
+# Place cursor launcher into ~/.local/bin from local file or GitHub
+log_step "Preparing cursor launcher script..."
+if [ -f "$LOCAL_CURSOR_SH" ]; then
+    log_info "Using local cursor.sh from repository"
+    cp "$LOCAL_CURSOR_SH" "$LOCAL_BIN/cursor"
+else
+    log_info "Downloading cursor.sh from GitHub..."
+curl -fsSL "$CURSOR_SCRIPT_URL" -o "$LOCAL_BIN/cursor" || {
+    echo "Failed to download cursor.sh from GitHub" >&2
+    exit 1
+}
+fi
 
 # Make the script executable
 chmod +x "$LOCAL_BIN/cursor"
 
-echo "Cursor installer script has been placed in $LOCAL_BIN/cursor"
+log_ok "Cursor installer script has been placed in $LOCAL_BIN/cursor"
 
 # Check if ~/.local/bin is in PATH
 if [[ ":$PATH:" != *":$LOCAL_BIN:"* ]]; then
-    echo "Warning: $LOCAL_BIN is not in your PATH."
-    echo "To add it, run this command or add it to your shell profile:"
-    echo "export PATH=\"\$HOME/.local/bin:\$PATH\""
+    log_warn "$LOCAL_BIN is not in your PATH."
+    log_info "To add it, run this or add it to your shell profile:"
+    log_info "export PATH=\"\$HOME/.local/bin:\$PATH\""
 fi
 
 # Run cursor --update to download and install Cursor
-echo "Downloading and installing Cursor ($INSTALL_MODE mode)..."
+log_step "Downloading and installing Cursor ($INSTALL_MODE mode) from ${REPO_OWNER}/${REPO_NAME}@${REPO_BRANCH}..."
 if [ "$INSTALL_MODE" = "extracted" ]; then
     "$LOCAL_BIN/cursor" --extract --update "$RELEASE_TRACK"
 else
     "$LOCAL_BIN/cursor" --update "$RELEASE_TRACK"
 fi
 
-echo "Installation complete. You can now run 'cursor' to start Cursor."
+log_ok "Installation complete. You can now run 'cursor' to start Cursor."
 

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 set -e
 
 # URL of the cursor.sh script in the GitHub repository
-CURSOR_SCRIPT_URL="https://raw.githubusercontent.com/watzon/cursor-linux-installer/main/cursor.sh"
+CURSOR_SCRIPT_URL="https://raw.githubusercontent.com/ZanzyTHEbar/cursor-linux-installer/main/cursor.sh"
 
 # Local bin directory
 LOCAL_BIN="$HOME/.local/bin"

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,28 @@
 
 set -e
 
+# Parse arguments
+RELEASE_TRACK="stable"
+INSTALL_MODE="appimage"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --extract|--no-fuse)
+            INSTALL_MODE="extracted"
+            shift
+            ;;
+        stable|latest)
+            RELEASE_TRACK="$1"
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Usage: bash install.sh [stable|latest] [--extract|--no-fuse]"
+            exit 1
+            ;;
+    esac
+done
+
 # URL of the cursor.sh script in the GitHub repository
 CURSOR_SCRIPT_URL="https://raw.githubusercontent.com/ZanzyTHEbar/cursor-linux-installer/personal/cursor.sh"
 
@@ -28,8 +50,12 @@ if [[ ":$PATH:" != *":$LOCAL_BIN:"* ]]; then
 fi
 
 # Run cursor --update to download and install Cursor
-echo "Downloading and installing Cursor..."
-"$LOCAL_BIN/cursor" --update "$@"
+echo "Downloading and installing Cursor ($INSTALL_MODE mode)..."
+if [ "$INSTALL_MODE" = "extracted" ]; then
+    "$LOCAL_BIN/cursor" --extract --update "$RELEASE_TRACK"
+else
+    "$LOCAL_BIN/cursor" --update "$RELEASE_TRACK"
+fi
 
 echo "Installation complete. You can now run 'cursor' to start Cursor."
 

--- a/scripts/check-links.sh
+++ b/scripts/check-links.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Verify no non-canonical links remain in tracked files.
+# Canonical: watzon/cursor-linux-installer@main
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+
+echo "Checking for non-canonical links..."
+
+# Any raw.githubusercontent.com links not pointing to watzon/main
+violations_raw=$(grep -RInE "raw\.githubusercontent\.com/.*/cursor-linux-installer/.+" "$root" \
+  --include='*.sh' --include='README.md' | grep -v "watzon/cursor-linux-installer/main" || true)
+
+# Any github.com clone links not pointing to watzon
+violations_git=$(grep -RInE "github\.com/.*/cursor-linux-installer(\.git)?" "$root" \
+  --include='*.sh' --include='README.md' | grep -v "github\.com/watzon/cursor-linux-installer" || true)
+
+violations="${violations_raw}
+${violations_git}"
+
+if [[ -n "$(echo "$violations" | sed '/^$/d')" ]]; then
+  echo "Found personal links in the following locations:" >&2
+  echo "$violations" >&2
+  exit 1
+fi
+
+# Enforce canonical defaults in install.sh
+install_sh="$root/install.sh"
+# shellcheck disable=SC2016
+if ! grep -q '^REPO_OWNER=${REPO_OWNER:-watzon}' "$install_sh"; then
+  echo "install.sh REPO_OWNER default must be 'watzon' on main" >&2
+  exit 1
+fi
+# shellcheck disable=SC2016
+if ! grep -q '^REPO_BRANCH=${REPO_BRANCH:-main}' "$install_sh"; then
+  echo "install.sh REPO_BRANCH default must be 'main' on main" >&2
+  exit 1
+fi
+
+echo "No non-canonical links found and canonical defaults are correct."
+
+

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -21,10 +21,12 @@ function find_cursor_appimage() {
     local search_dirs=("$HOME/AppImages" "$HOME/Applications" "$HOME/.local/bin")
     for dir in "${search_dirs[@]}"; do
         local appimage
-        appimage=$(find "$dir" -name "cursor.appimage" -print -quit 2>/dev/null)
-        if [ -n "$appimage" ]; then
-            echo "$appimage"
-            return 0
+        if [ -d "$dir" ]; then
+            appimage=$(find "$dir" -name "cursor.appimage" -print -quit 2>/dev/null || true)
+            if [ -n "$appimage" ]; then
+                echo "$appimage"
+                return 0
+            fi
         fi
     done
     return 1

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -2,7 +2,19 @@
 
 set -e
 
-echo "Uninstalling Cursor..."
+# Color and logging helpers
+if [ -t 1 ]; then
+    BOLD="\033[1m"; RESET="\033[0m"; RED="\033[31m"; GREEN="\033[32m"; YELLOW="\033[33m"; BLUE="\033[34m"
+else
+    BOLD=""; RESET=""; RED=""; GREEN=""; YELLOW=""; BLUE=""
+fi
+log_info()  { echo -e "${BLUE}[*]${RESET} $*"; }
+log_ok()    { echo -e "${GREEN}[✓]${RESET} $*"; }
+log_warn()  { echo -e "${YELLOW}[!]${RESET} $*"; }
+log_error() { echo -e "${RED}[x]${RESET} $*"; }
+log_step()  { echo -e "${BOLD}$*${RESET}"; }
+
+log_step "Uninstalling Cursor..."
 
 # Function to find the Cursor AppImage
 function find_cursor_appimage() {
@@ -21,33 +33,33 @@ function find_cursor_appimage() {
 # Remove the Cursor AppImage
 cursor_appimage=$(find_cursor_appimage)
 if [ -n "$cursor_appimage" ]; then
-    echo "Removing Cursor AppImage..."
+    log_step "Removing Cursor AppImage..."
     rm -f "$cursor_appimage"
 else
-    echo "Cursor AppImage not found."
+    log_warn "Cursor AppImage not found."
 fi
 
 # Remove the cursor script from ~/.local/bin
-echo "Removing Cursor script..."
+log_step "Removing Cursor script..."
 rm -f "$HOME/.local/bin/cursor"
 
 # Remove icons
-echo "Removing Cursor icons..."
+log_step "Removing Cursor icons..."
 find "$HOME/.local/share/icons/hicolor" -name "cursor.png" -delete
 
 # Remove desktop file
-echo "Removing Cursor desktop file..."
+log_step "Removing Cursor desktop file..."
 rm -f "$HOME/.local/share/applications/cursor.desktop"
 
-echo "Cursor has been uninstalled."
+log_ok "Cursor has been uninstalled."
 
 # Optionally, ask the user if they want to remove configuration files
 read -r -p "Do you want to remove Cursor configuration files? (y/N) " remove_config
 if [[ $remove_config =~ ^[Yy]$ ]]; then
-    echo "Removing Cursor configuration files..."
+    log_step "Removing Cursor configuration files..."
     rm -rf "$HOME/.config/Cursor"
-    echo "Configuration files removed."
+    log_ok "Configuration files removed."
 fi
 
-echo "Uninstallation complete."
+log_ok "Uninstallation complete."
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -45,11 +45,19 @@ rm -f "$HOME/.local/bin/cursor"
 
 # Remove icons
 log_step "Removing Cursor icons..."
-find "$HOME/.local/share/icons/hicolor" -name "cursor.png" -delete
+# Remove any 'cursor' or legacy 'co.anysphere.cursor' icons under hicolor theme
+find "$HOME/.local/share/icons/hicolor" -type f \
+	\( -name 'cursor.*' -o -name 'co.anysphere.cursor.*' \) \
+	-path '*/apps/*' -delete 2>/dev/null || true
+# Clean up now-empty directories
+find "$HOME/.local/share/icons/hicolor" -type d -empty -delete 2>/dev/null || true
 
 # Remove desktop file
 log_step "Removing Cursor desktop file..."
 rm -f "$HOME/.local/share/applications/cursor.desktop"
+
+# Refresh desktop database for menu visibility cleanup
+update-desktop-database "$HOME/.local/share/applications" 2>/dev/null || true
 
 log_ok "Cursor has been uninstalled."
 
@@ -60,6 +68,11 @@ if [[ $remove_config =~ ^[Yy]$ ]]; then
     rm -rf "$HOME/.config/Cursor"
     log_ok "Configuration files removed."
 fi
+
+# Also remove extracted installations (FUSE-free mode) and related metadata
+log_step "Removing extracted installation directories..."
+rm -rf "$HOME/.local/share/cursor" "$HOME/.cursor"
+log_ok "Extracted installation directories removed (if present)."
 
 log_ok "Uninstallation complete."
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -47,7 +47,9 @@ rm -f "$HOME/.local/bin/cursor"
 
 # Remove icons
 log_step "Removing Cursor icons..."
-find "$HOME/.local/share/icons/hicolor" -name "cursor.png" -delete
+if [ -d "$HOME/.local/share/icons/hicolor" ]; then
+    find "$HOME/.local/share/icons/hicolor" -name "cursor.png" -delete
+fi
 
 # Remove desktop file
 log_step "Removing Cursor desktop file..."

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -8,7 +8,8 @@ echo "Uninstalling Cursor..."
 function find_cursor_appimage() {
     local search_dirs=("$HOME/AppImages" "$HOME/Applications" "$HOME/.local/bin")
     for dir in "${search_dirs[@]}"; do
-        local appimage=$(find "$dir" -name "cursor.appimage" -print -quit 2>/dev/null)
+        local appimage
+        appimage=$(find "$dir" -name "cursor.appimage" -print -quit 2>/dev/null)
         if [ -n "$appimage" ]; then
             echo "$appimage"
             return 0
@@ -41,7 +42,7 @@ rm -f "$HOME/.local/share/applications/cursor.desktop"
 echo "Cursor has been uninstalled."
 
 # Optionally, ask the user if they want to remove configuration files
-read -p "Do you want to remove Cursor configuration files? (y/N) " remove_config
+read -r -p "Do you want to remove Cursor configuration files? (y/N) " remove_config
 if [[ $remove_config =~ ^[Yy]$ ]]; then
     echo "Removing Cursor configuration files..."
     rm -rf "$HOME/.config/Cursor"


### PR DESCRIPTION
## Summary

This PR merges recent improvements from `personal` into `main`, focusing on a cleaner install experience, canonical-link enforcement, and better maintainability via a few QoL features and DX improvements,.

## Key Changes

### Installation and Execution

- feat(cursor.sh): Add extracted installation mode (FUSE-free) with proper environment setup and launcher script generation.
- feat(install.sh): Support both remote (canonical) and local repo installs; default to `watzon/main` with env overrides (`REPO_OWNER`, `REPO_BRANCH`, `REPO_NAME`).
- refactor(cursor.sh, uninstall.sh): Simplify variable assignments; fix shellcheck warnings; guard non-interactive flows and preserve set -e behavior safely.

### UX and Logging

- feat: Introduce consistent, colorized logging helpers (log_step, log_info, log_ok, log_warn, log_error) across scripts.
- enhance(cursor.sh): More informative progress during downloads, extraction, and validation with clear success/failure messages.

### Canonical Enforcement

- chore(.githooks/pre-push): Add Git pre-push hook that blocks pushes to `main` when non-canonical links or defaults are detected.
- chore(scripts/check-links.sh): CI/local check to ensure:
  - No `raw.githubusercontent.com` or `github.com` links outside `watzon/cursor-linux-installer@main`.
  - `install.sh` defaults are `REPO_OWNER=watzon`, `REPO_BRANCH=main`.
- ci(.github/workflows/enforce-canonical.yml): GitHub Action to enforce canonical links/defaults on pushes and PRs to `main`.

### Documentation

- docs(README.md):
  - Update one-liners to canonical (`watzon/main`).
  - Clarify two install methods (one-liner vs local clone).
  - Document env overrides for personal testing without polluting upstream defaults.
  - Add instructions to enable the pre-push hook (`git config core.hooksPath .githooks`).

## Rationale

- Ensures `main` remains canonical while allowing personal testing via environment variables.
- Improves reliability in non-interactive environments (piped installs) and provides clearer feedback during long operations.
- Introduces a FUSE-free extracted mode for environments where FUSE isn’t available or desired.

## Testing

- Local run of `./install.sh latest`:
  - Verified AppImage flow: download, chmod, arch validation, icon/desktop extraction.
  - Verified extracted mode: full extraction, environment setup, launcher creation, desktop entry fixup.
- Pre-push hook:
  - Blocks pushes to `main` when non-canonical links or defaults are found.
- CI:
  - Workflow verifies canonical constraints on PRs and pushes to `main`.

## Files Changed

- .githooks/pre-push
- .github/workflows/enforce-canonical.yml
- README.md
- cursor.sh
- install.sh
- scripts/check-links.sh
- uninstall.sh

## Notes

- Canonical defaults are now used automatically (`watzon/main`).
- For personal testing:
  ```bash
  export REPO_OWNER="ZanzyTHEbar"
  export REPO_BRANCH="personal"
  ./install.sh latest
  ```
